### PR TITLE
Activate extension for C files so hover works in .c/.h

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "vscode": "^1.75.0"
   },
   "activationEvents": [
-    "onLanguage:basilisk"
+    "onLanguage:basilisk",
+    "onLanguage:c"
   ],
   "main": "./client/out/extension.js",
   "bin": {


### PR DESCRIPTION
### Motivation
- Ensure the language client activates for built-in C language buffers so hover/documentation from the LSP is available in `.c`/`.h` files.

### Description
- Add the `"onLanguage:c"` activation event to `package.json` so the extension starts for files detected as the `c` language.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f5a9c5174832ab074ec9b133737b8)