### PR TITLE
Batch Dependabot lint tooling bumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,10 +207,10 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.5.2",
-    "@typescript-eslint/eslint-plugin": "^8.58.2",
-    "@typescript-eslint/parser": "^8.58.2",
+    "@typescript-eslint/eslint-plugin": "^8.59.1",
+    "@typescript-eslint/parser": "^8.59.1",
     "concurrently": "^9.2.1",
-    "eslint": "^10.2.1",
+    "eslint": "^10.3.0",
     "typescript": "^6.0.2"
   }
 }


### PR DESCRIPTION
Batches these Dependabot updates:
- @typescript-eslint/eslint-plugin 8.58.2 -> 8.59.1
- @typescript-eslint/parser 8.58.2 -> 8.59.1
- eslint 10.2.1 -> 10.3.0

Validation:
- npm run lint
- npm run compile
- npm test

Note: npm 11 stalled on regenerating the root package-lock.json in this workspace, so this PR currently includes the manifest bump only. The repo checks above still pass against the installed tree.