### PR TITLE
Batch remaining Dependabot npm upgrades

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,10 +12,10 @@
         "vscode-languageclient": "^9.0.1"
       },
       "devDependencies": {
-        "@types/node": "^25.5.2",
-        "@types/vscode": "^1.110.0",
+        "@types/node": "^26.0.0",
+        "@types/vscode": "^1.125.0",
         "jest": "^30.2.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1153,13 +1153,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -1170,9 +1170,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
-      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4079,9 +4079,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4093,9 +4093,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/client/package.json
+++ b/client/package.json
@@ -14,9 +14,9 @@
     "vscode-languageclient": "^9.0.1"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
-    "@types/vscode": "^1.110.0",
+    "@types/node": "^26.0.0",
+    "@types/vscode": "^1.125.0",
     "jest": "^30.2.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,12 +18,12 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@types/node": "^25.5.2",
+        "@types/node": "^26.0.0",
         "@typescript-eslint/eslint-plugin": "^8.61.1",
         "@typescript-eslint/parser": "^8.61.1",
-        "concurrently": "^9.2.1",
+        "concurrently": "^9.2.3",
         "eslint": "^10.5.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20.19.0",
@@ -219,13 +219,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -537,9 +537,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -614,15 +614,15 @@
       "license": "MIT"
     },
     "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.3.tgz",
+      "integrity": "sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
+        "shell-quote": "1.8.4",
         "supports-color": "8.1.1",
         "tree-kill": "1.2.2",
         "yargs": "17.7.2"
@@ -1331,9 +1331,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1448,9 +1448,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1462,9 +1462,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -206,12 +206,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.5.2",
+    "@types/node": "^26.0.0",
     "@typescript-eslint/eslint-plugin": "^8.61.1",
     "@typescript-eslint/parser": "^8.61.1",
-    "concurrently": "^9.2.1",
+    "concurrently": "^9.2.3",
     "eslint": "^10.5.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "vscode-languageclient": "^10.0.0",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "dependencies": {
-    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver": "^10.0.0",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "^3.1.0"
   },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver": "^10.0.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-uri": "^3.1.0"
       },
@@ -4318,34 +4318,34 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0.tgz",
+      "integrity": "sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.0.0.tgz",
+      "integrity": "sha512-KOdOVuBnNO5EZSejlEDdRPJWpJn/X87vR2TmOXneHsxSYY7mYjgc1SxeZPMoHICcBKTUnM0V19+WP4J92zDd1w==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.0"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.0.tgz",
+      "integrity": "sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.0",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -4355,9 +4355,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/vscode-uri": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,10 +15,10 @@
       },
       "devDependencies": {
         "@types/jest": "^30.0.0",
-        "@types/node": "^25.5.2",
+        "@types/node": "^26.0.0",
         "jest": "^30.3.0",
         "ts-jest": "^29.4.9",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -1148,13 +1148,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -4202,9 +4202,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4230,9 +4230,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/server/package.json
+++ b/server/package.json
@@ -20,9 +20,9 @@
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
-    "@types/node": "^25.5.2",
+    "@types/node": "^26.0.0",
     "jest": "^30.3.0",
     "ts-jest": "^29.4.9",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint ./src --ext .ts"
   },
   "dependencies": {
-    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver": "^10.0.0",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "^3.1.0"
   },

--- a/server/src/basiliskDetect.ts
+++ b/server/src/basiliskDetect.ts
@@ -12,6 +12,7 @@ import {
   CONSTANTS,
   LOOP_VARIABLES
 } from './basiliskLanguage';
+import { diagnosticMessageText } from './diagnosticMessage';
 
 const BASILISK_TOKENS = [
   ...CONTROL_KEYWORDS,
@@ -70,6 +71,7 @@ export function filterClangdDiagnostics(
       return true;
     }
 
-    return !NOISE_PATTERNS.some((pattern) => pattern.test(diagnostic.message));
+    const message = diagnosticMessageText(diagnostic.message);
+    return !NOISE_PATTERNS.some((pattern) => pattern.test(message));
   });
 }

--- a/server/src/cli.ts
+++ b/server/src/cli.ts
@@ -33,6 +33,7 @@ import {
 } from './clangdConfig';
 import { resolveExecutableOnPath } from './pathUtils';
 import { filterClangdDiagnostics } from './basiliskDetect';
+import { diagnosticMessageText } from './diagnosticMessage';
 
 type OutputFormat = 'text' | 'json';
 
@@ -508,7 +509,7 @@ function formatDiagnostic(
         ? 'info'
         : 'hint';
   const source = diagnostic.source ? `${diagnostic.source}: ` : '';
-  return `${filePath}:${line}:${col}: ${severity}: ${source}${diagnostic.message}`;
+  return `${filePath}:${line}:${col}: ${severity}: ${source}${diagnosticMessageText(diagnostic.message)}`;
 }
 
 function dedupeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
@@ -522,7 +523,7 @@ function dedupeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
       diagnostic.range.end.line,
       diagnostic.range.end.character,
       diagnostic.severity ?? '',
-      diagnostic.message,
+      diagnosticMessageText(diagnostic.message),
       diagnostic.source ?? ''
     ].join(':');
     if (seen.has(key)) {

--- a/server/src/diagnosticMessage.ts
+++ b/server/src/diagnosticMessage.ts
@@ -1,0 +1,5 @@
+import type { Diagnostic } from 'vscode-languageserver/node';
+
+export function diagnosticMessageText(message: Diagnostic['message']): string {
+  return typeof message === 'string' ? message : message.value;
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -73,6 +73,7 @@ import {
   mergeFlags
 } from './clangdConfig';
 import { filterClangdDiagnostics } from './basiliskDetect';
+import { diagnosticMessageText } from './diagnosticMessage';
 import { loadProjectConfig, ProjectConfig, findSrcLocalDir } from './projectConfig';
 
 // Create connection and document manager
@@ -756,7 +757,7 @@ function dedupeDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
       diagnostic.range.end.line,
       diagnostic.range.end.character,
       diagnostic.severity ?? '',
-      diagnostic.message,
+      diagnosticMessageText(diagnostic.message),
       diagnostic.source ?? ''
     ].join(':');
     if (seen.has(key)) {

--- a/server/test/diagnostics.test.ts
+++ b/server/test/diagnostics.test.ts
@@ -1,17 +1,18 @@
 import { DiagnosticSeverity } from 'vscode-languageserver';
 import { quickValidate } from '../src/diagnostics';
+import { diagnosticMessageText } from '../src/diagnosticMessage';
 
 describe('diagnostics', () => {
   test('quickValidate flags scalar declarations without []', () => {
     const diagnostics = quickValidate('scalar f;\n');
-    const messages = diagnostics.map((diag) => diag.message);
+    const messages = diagnostics.map((diag) => diagnosticMessageText(diag.message));
     expect(messages.some((message) => message.includes("Field 'f'"))).toBe(true);
   });
 
   test('quickValidate flags event definitions without parentheses', () => {
     const diagnostics = quickValidate('event init t = 0;\n');
     const hasEventError = diagnostics.some(
-      (diag) => diag.severity === DiagnosticSeverity.Error && diag.message.includes('Event definition')
+      (diag) => diag.severity === DiagnosticSeverity.Error && diagnosticMessageText(diag.message).includes('Event definition')
     );
     expect(hasEventError).toBe(true);
   });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -8,6 +8,7 @@
     "sourceMap": true,
     "strict": true,
     "esModuleInterop": true,
+    "types": ["node"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- Batch the remaining open Dependabot npm updates into one reviewed upgrade PR.
- Cover the root, client, server, and packages/npm dependency surfaces without adding new direct dependencies.

## Changes
- Update root TypeScript tooling to `@types/node` 26.0.0 and `typescript` 6.0.3.
- Update root `concurrently` to 9.2.3, bringing `shell-quote` 1.8.4, and refresh the `brace-expansion` 5.0.6 lockfile entry.
- Update client/server TypeScript tooling to the Dependabot-requested versions.
- Update `packages/npm` `vscode-languageserver` to 10.0.0.

Supersedes Dependabot PRs #97, #98, #99, #100, #107, and #119.

## Testing
- `npm ci`
- `npm run lint`
- `npm test`
- `npm run compile`
- `python3 /Users/comphy-mac/.codex/plugins/cache/codex-vatsal-marketplace/jarvis/1.0.92/skills/gh-dependabot-batch-pr/scripts/run_repo_checks.py --require-scripts`
